### PR TITLE
Fix pandas import for profiling

### DIFF
--- a/phases/01_LegacyDB/src/profiling_modules/metrics_profile.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_profile.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, List
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
+import pandas as pd
+
 from .base import get_table_names
 
 


### PR DESCRIPTION
## Summary
- add missing pandas import to column profiling module

## Testing
- `pytest -q`
- import `profiling_modules.metrics_profile` module

------
https://chatgpt.com/codex/tasks/task_e_6849f0bcfb68832dba781a671bc8c92e

## Summary by Sourcery

Bug Fixes:
- Add missing "import pandas as pd" to profiling_modules.metrics_profile to fix import errors during profiling