### PR TITLE
Replace f-string logging in phase 1 scripts

### DIFF
--- a/phases/01_LegacyDB/src/02_run_profiling_pipeline.py
+++ b/phases/01_LegacyDB/src/02_run_profiling_pipeline.py
@@ -101,7 +101,9 @@ def save_results(
     """Saves profiling data to a CSV or JSON file."""
     if not data:
         logging.warning(
-            f"No data to save for metric '{metric_name}' on db '{db_name}'."
+            "No data to save for metric '%s' on db '%s'.",
+            metric_name,
+            db_name,
         )
         return
 

--- a/phases/01_LegacyDB/src/03_generate_erds.py
+++ b/phases/01_LegacyDB/src/03_generate_erds.py
@@ -47,21 +47,45 @@ OUTPUT_ERDS_DIR = "outputs/erds"
 # Each key is a subsystem name, and the value is a list of table names.
 TMP_DF9_SUBSYSTEMS = {
     "Core_Data_Tables": [
-        "location", "description", "archInterp", "admin", "lithicFlaked",
-        "lithicGround", "cerVessel", "cerPhTot", "condition", "figurine",
-        "plasterFloor", "archaeology", "artifactOther", "architecture",
-        "cerNonVessel", "complexData", "complexMacroData"
+        "location",
+        "description",
+        "archInterp",
+        "admin",
+        "lithicFlaked",
+        "lithicGround",
+        "cerVessel",
+        "cerPhTot",
+        "condition",
+        "figurine",
+        "plasterFloor",
+        "archaeology",
+        "artifactOther",
+        "architecture",
+        "cerNonVessel",
+        "complexData",
+        "complexMacroData",
     ],
     "Ceramic_System": [
-        "cerVessel", "cerPhTot", "cerNonVessel", "Codes_Ware",
-        "Codes_Ceramic_Variety", "Codes_Ceramic_Form", "Codes_Ceramic_Type",
-        "Codes_Phase"
+        "cerVessel",
+        "cerPhTot",
+        "cerNonVessel",
+        "Codes_Ware",
+        "Codes_Ceramic_Variety",
+        "Codes_Ceramic_Form",
+        "Codes_Ceramic_Type",
+        "Codes_Phase",
     ],
     "Lithic_System": [
-        "lithicFlaked", "lithicGround", "Codes_Material", "Codes_Core_Type",
-        "Codes_Biface_Type", "Codes_Blade_Type", "Codes_Flake_Type",
-        "Codes_Projectile_Pt", "Codes_Scraper_Type"
-    ]
+        "lithicFlaked",
+        "lithicGround",
+        "Codes_Material",
+        "Codes_Core_Type",
+        "Codes_Biface_Type",
+        "Codes_Blade_Type",
+        "Codes_Flake_Type",
+        "Codes_Projectile_Pt",
+        "Codes_Scraper_Type",
+    ],
 }
 
 
@@ -74,10 +98,11 @@ def setup_logging(log_dir: Path) -> None:
         level=logging.INFO,
         format="%(asctime)s [%(levelname)-7s] %(name)s: %(message)s",
         handlers=[
-            logging.FileHandler(log_path, mode='w'),
-            logging.StreamHandler(sys.stdout)
-        ]
+            logging.FileHandler(log_path, mode="w"),
+            logging.StreamHandler(sys.stdout),
+        ],
     )
+
 
 def parse_arguments() -> argparse.Namespace:
     """Parses command-line arguments."""
@@ -85,10 +110,13 @@ def parse_arguments() -> argparse.Namespace:
         description="Generate ERDs for all project databases."
     )
     parser.add_argument(
-        "--config", type=str, default="config.ini",
-        help="Path to the configuration file (default: config.ini)"
+        "--config",
+        type=str,
+        default="config.ini",
+        help="Path to the configuration file (default: config.ini)",
     )
     return parser.parse_args()
+
 
 def get_sqlalchemy_engine(db_config: Dict[str, Any], db_name: str) -> Engine | None:
     """Creates a SQLAlchemy engine, returning None on failure."""
@@ -99,12 +127,17 @@ def get_sqlalchemy_engine(db_config: Dict[str, Any], db_name: str) -> Engine | N
         )
         return create_engine(db_url)
     except Exception as e:
-        logging.error(f"Failed to create SQLAlchemy engine for '{db_name}': {e}")
+        logging.error(
+            "Failed to create SQLAlchemy engine for '%s': %s",
+            db_name,
+            e,
+        )
         return None
+
 
 def get_schema_for_db(db_name: str, legacy_dbs: List[str]) -> str:
     """Determines the correct schema name for a given database name."""
-    return db_name if db_name in legacy_dbs else 'public'
+    return db_name if db_name in legacy_dbs else "public"
 
 
 # --- Core Graphing Logic ---
@@ -112,7 +145,7 @@ def generate_and_save_erd(
     metadata: MetaData,
     output_path: Path,
     tables_to_include: Optional[List[Table]] = None,
-    graph_title: str = ""
+    graph_title: str = "",
 ) -> None:
     """
     Generates a single ERD using Graphviz and saves it as an SVG.
@@ -124,7 +157,11 @@ def generate_and_save_erd(
                            If None, all tables in metadata are used.
         graph_title: A title to display on the generated graph.
     """
-    logging.info(f"Generating ERD for '{graph_title}' -> {output_path.name}")
+    logging.info(
+        "Generating ERD for '%s' -> %s",
+        graph_title,
+        output_path.name,
+    )
     try:
         # Graphviz attributes for improved readability
         graph = create_schema_graph(
@@ -132,16 +169,21 @@ def generate_and_save_erd(
             tables=tables_to_include,
             show_datatypes=False,
             show_indexes=False,
-            rankdir='LR',  # Left-to-Right layout
+            rankdir="LR",  # Left-to-Right layout
             concentrate=False,
-            graph_attr={'label': graph_title, 'labelloc': 't', 'fontsize': '20'},
-            node_attr={'fontname': 'Helvetica', 'fontsize': '10'},
-            edge_attr={'fontname': 'Helvetica', 'fontsize': '8'}
+            graph_attr={"label": graph_title, "labelloc": "t", "fontsize": "20"},
+            node_attr={"fontname": "Helvetica", "fontsize": "10"},
+            edge_attr={"fontname": "Helvetica", "fontsize": "8"},
         )
         graph.write_svg(str(output_path))
         logging.info("Successfully generated SVG.")
     except Exception as e:
-        logging.error(f"Failed to generate ERD for '{graph_title}'. Error: {e}", exc_info=True)
+        logging.error(
+            "Failed to generate ERD for '%s'. Error: %s",
+            graph_title,
+            e,
+            exc_info=True,
+        )
 
 
 # --- Main Orchestrator ---
@@ -154,9 +196,9 @@ def main() -> None:
     setup_logging(log_dir)
     logging.info("--- Starting ERD Generation Pipeline ---")
 
-    logging.info(f"Reading configuration from: {config_path}")
+    logging.info("Reading configuration from: %s", config_path)
     if not config_path.is_file():
-        logging.critical(f"Configuration file not found: {config_path}")
+        logging.critical("Configuration file not found: %s", config_path)
         sys.exit(1)
 
     config = configparser.ConfigParser()
@@ -164,37 +206,56 @@ def main() -> None:
 
     try:
         db_config_root = dict(config["postgresql"])
-        legacy_dbs = [db.strip() for db in config.get("databases", "legacy_dbs").split(',')]
-        benchmark_dbs = [db.strip() for db in config.get("databases", "benchmark_dbs").split(',')]
+        legacy_dbs = [
+            db.strip() for db in config.get("databases", "legacy_dbs").split(",")
+        ]
+        benchmark_dbs = [
+            db.strip() for db in config.get("databases", "benchmark_dbs").split(",")
+        ]
         all_dbs_to_profile = legacy_dbs + benchmark_dbs
-        
+
         project_root = Path(__file__).parent.parent
         output_dir = project_root / OUTPUT_ERDS_DIR
         output_dir.mkdir(parents=True, exist_ok=True)
-        
+
     except (configparser.NoSectionError, configparser.NoOptionError) as e:
-        logging.critical(f"Config file is missing a required section or option: {e}")
+        logging.critical(
+            "Config file is missing a required section or option: %s",
+            e,
+        )
         sys.exit(1)
 
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
 
     for i, db_name in enumerate(all_dbs_to_profile, 1):
-        logging.info("="*80)
-        logging.info(f"Processing Database {i}/{len(all_dbs_to_profile)}: {db_name}")
-        logging.info("="*80)
+        logging.info("=" * 80)
+        logging.info(
+            "Processing Database %s/%s: %s",
+            i,
+            len(all_dbs_to_profile),
+            db_name,
+        )
+        logging.info("=" * 80)
 
         engine = get_sqlalchemy_engine(db_config_root, db_name)
         if not engine:
-            logging.error(f"Skipping ERD generation for '{db_name}' due to connection failure.")
+            logging.error(
+                "Skipping ERD generation for '%s' due to connection failure.",
+                db_name,
+            )
             continue
 
         schema_name = get_schema_for_db(db_name, legacy_dbs)
-        logging.info(f"Reflecting schema '{schema_name}'...")
+        logging.info("Reflecting schema '%s'...", schema_name)
         metadata = MetaData()
         try:
             metadata.reflect(bind=engine, schema=schema_name)
         except Exception as e:
-            logging.error(f"Could not reflect schema '{schema_name}'. Skipping. Error: {e}")
+            logging.error(
+                "Could not reflect schema '%s'. Skipping. Error: %s",
+                schema_name,
+                e,
+            )
             continue
 
         # 1. Generate the full ERD for every database
@@ -202,33 +263,38 @@ def main() -> None:
         generate_and_save_erd(
             metadata=metadata,
             output_path=full_erd_path,
-            graph_title=f"Full ERD for {db_name}"
+            graph_title=f"Full ERD for {db_name}",
         )
 
         # 2. For tmp_df9, generate additional focused ERDs
-        if db_name == 'tmp_df9':
-            logging.info(f"Generating focused ERDs for '{db_name}'...")
+        if db_name == "tmp_df9":
+            logging.info("Generating focused ERDs for '%s'...", db_name)
             for subsystem_name, table_list in TMP_DF9_SUBSYSTEMS.items():
-                
+
                 # Filter the reflected tables to only those in our subsystem list
                 tables_to_include = [
-                    table for name, table in metadata.tables.items()
-                    if name.split('.')[-1] in table_list
+                    table
+                    for name, table in metadata.tables.items()
+                    if name.split(".")[-1] in table_list
                 ]
-                
+
                 if not tables_to_include:
-                    logging.warning(f"No tables found for subsystem '{subsystem_name}'. Skipping.")
+                    logging.warning(
+                        f"No tables found for subsystem '{subsystem_name}'. Skipping."
+                    )
                     continue
 
-                focused_erd_path = output_dir / f"{db_name}_focused_{subsystem_name}_{timestamp}.svg"
+                focused_erd_path = (
+                    output_dir / f"{db_name}_focused_{subsystem_name}_{timestamp}.svg"
+                )
                 generate_and_save_erd(
                     metadata=metadata,
                     output_path=focused_erd_path,
                     tables_to_include=tables_to_include,
-                    graph_title=f"{db_name} - {subsystem_name}"
+                    graph_title=f"{db_name} - {subsystem_name}",
                 )
 
-    logging.info("="*80)
+    logging.info("=" * 80)
     logging.info("--- ERD Generation Pipeline Finished ---")
 
 

--- a/phases/01_LegacyDB/src/04_run_comparison.py
+++ b/phases/01_LegacyDB/src/04_run_comparison.py
@@ -111,7 +111,7 @@ def load_all_metrics(input_dir: Path) -> Dict[str, Dict[str, Any]]:
 
             if not db_name:
                 logging.warning(
-                    f"Could not determine database name for '{file_path.name}'. Skipping."
+                    "Could not determine database name for '%s'. Skipping.", file_path.name
                 )
                 continue
 

--- a/phases/01_LegacyDB/src/profiling_modules/base.py
+++ b/phases/01_LegacyDB/src/profiling_modules/base.py
@@ -30,8 +30,13 @@ def get_table_names(engine: Engine, schema_name: str) -> List[str]:
             result = connection.execute(query, {"schema": schema_name})
             return [row[0] for row in result]
     except Exception as e:
-        logging.error(f"Failed to get table names for schema '{schema_name}': {e}")
+        logging.error(
+            "Failed to get table names for schema '%s': %s",
+            schema_name,
+            e,
+        )
         return []
+
 
 def get_view_names(engine: Engine, schema_name: str) -> List[str]:
     """
@@ -56,5 +61,9 @@ def get_view_names(engine: Engine, schema_name: str) -> List[str]:
             result = connection.execute(query, {"schema": schema_name})
             return [row[0] for row in result]
     except Exception as e:
-        logging.error(f"Failed to get view names for schema '{schema_name}': {e}")
+        logging.error(
+            "Failed to get view names for schema '%s': %s",
+            schema_name,
+            e,
+        )
         return []

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_basic.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_basic.py
@@ -27,14 +27,19 @@ def get_basic_db_metrics(engine: Engine) -> Dict[str, Any]:
             metrics["database_name"] = db_name_result.scalar_one()
 
             # Get database size
-            db_size_query = text("SELECT pg_catalog.pg_database_size(current_database()) / (1024 * 1024);")
+            db_size_query = text(
+                "SELECT pg_catalog.pg_database_size(current_database()) / (1024 * 1024);"
+            )
             db_size_result = connection.execute(db_size_query)
             metrics["database_size_mb"] = round(db_size_result.scalar_one(), 2)
-            
-            logging.info(f"Successfully retrieved basic metrics for DB '{metrics['database_name']}'.")
+
+            logging.info(
+                "Successfully retrieved basic metrics for DB '%s'.",
+                metrics["database_name"],
+            )
 
     except Exception as e:
-        logging.error(f"Failed to retrieve basic DB metrics: {e}")
+        logging.error("Failed to retrieve basic DB metrics: %s", e)
 
     return metrics
 
@@ -57,10 +62,14 @@ def get_schema_object_counts(engine: Engine, schema_name: str) -> Dict[str, Any]
         "function_count": 0,
         "sequence_count": 0,
     }
-    
+
     queries = {
-        "function_count": text("SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema = :schema;"),
-        "sequence_count": text("SELECT COUNT(*) FROM information_schema.sequences WHERE sequence_schema = :schema;")
+        "function_count": text(
+            "SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema = :schema;"
+        ),
+        "sequence_count": text(
+            "SELECT COUNT(*) FROM information_schema.sequences WHERE sequence_schema = :schema;"
+        ),
     }
 
     try:
@@ -68,8 +77,15 @@ def get_schema_object_counts(engine: Engine, schema_name: str) -> Dict[str, Any]
             for key, query in queries.items():
                 result = connection.execute(query, {"schema": schema_name})
                 metrics[key] = result.scalar_one()
-        logging.info(f"Successfully counted objects for schema '{schema_name}'.")
+        logging.info(
+            "Successfully counted objects for schema '%s'.",
+            schema_name,
+        )
     except Exception as e:
-        logging.error(f"Failed to count objects for schema '{schema_name}': {e}")
+        logging.error(
+            "Failed to count objects for schema '%s': %s",
+            schema_name,
+            e,
+        )
 
     return metrics


### PR DESCRIPTION
## Summary
- convert `logging.info` and `logging.error` calls to `%s` formatting in phase 1
- clean up all phase 1 modules and scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `black phases/01_LegacyDB/src --check --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684aa3bbf9b0832d9723262cf0b221eb

## Summary by Sourcery

Refactor Phase 1 scripts and modules to improve consistency and maintainability by replacing f-string logging with %-format logging, standardizing string quoting and trailing commas, and cleaning up whitespace and formatting throughout.

Enhancements:
- Replace all f-string logging calls with %-style formatting across Phase 1 scripts and profiling modules
- Standardize string quoting to double quotes and ensure trailing commas in lists and function arguments
- Clean up whitespace, line breaks, and minor style inconsistencies for uniform code formatting