### PR TITLE
Fix formatting for legacy DB scripts

### DIFF
--- a/phases/01_LegacyDB/src/00_setup_databases.py
+++ b/phases/01_LegacyDB/src/00_setup_databases.py
@@ -32,6 +32,8 @@ from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
 LOG_FILE_NAME = "00_setup_databases.log"
 
 # --- Logging Setup ---
+
+
 def setup_logging(log_path: Path) -> None:
     """Configures logging to both console and a file."""
     logging.basicConfig(
@@ -44,6 +46,8 @@ def setup_logging(log_path: Path) -> None:
     )
 
 # --- Argument Parsing ---
+
+
 def parse_arguments() -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -58,6 +62,8 @@ def parse_arguments() -> argparse.Namespace:
     return parser.parse_args()
 
 # --- Database Operations ---
+
+
 def create_database(db_config: dict, db_name: str) -> bool:
     """
     Creates a new database in PostgreSQL if it doesn't already exist.
@@ -89,8 +95,9 @@ def create_database(db_config: dict, db_name: str) -> bool:
     except psycopg2.Error as e:
         logging.error(f"Failed to create database '{db_name}'. Error: {e}")
         return False
-    
+
     return True
+
 
 def populate_database(db_config: dict, db_name: str, sql_file_path: Path) -> bool:
     """
@@ -109,7 +116,7 @@ def populate_database(db_config: dict, db_name: str, sql_file_path: Path) -> boo
         return False
 
     logging.info(f"Populating '{db_name}' from '{sql_file_path.name}'...")
-    
+
     # Update config to connect to the newly created database
     target_db_config = db_config.copy()
     target_db_config["dbname"] = db_name
@@ -117,11 +124,11 @@ def populate_database(db_config: dict, db_name: str, sql_file_path: Path) -> boo
     try:
         with open(sql_file_path, 'r', encoding='utf-8') as f:
             sql_script = f.read()
-            
+
         with psycopg2.connect(**target_db_config) as conn:
             with conn.cursor() as cur:
                 cur.execute(sql_script)
-        
+
         logging.info(f"Successfully populated database '{db_name}'.")
 
     except psycopg2.Error as e:
@@ -130,15 +137,18 @@ def populate_database(db_config: dict, db_name: str, sql_file_path: Path) -> boo
     except IOError as e:
         logging.error(f"Could not read SQL file '{sql_file_path}'. Error: {e}")
         return False
-        
+
     return True
 
+
 # --- Main Orchestrator ---
+
+
 def main() -> None:
     """Main function to orchestrate database setup."""
     args = parse_arguments()
     config_path = Path(args.config)
-    
+
     # Assume log file is in the same directory as the script
     log_file_path = Path(__file__).parent / LOG_FILE_NAME
     setup_logging(log_file_path)
@@ -164,12 +174,12 @@ def main() -> None:
     except (configparser.NoSectionError, configparser.NoOptionError) as e:
         logging.critical(f"Configuration file is missing a required section or option: {e}")
         sys.exit(1)
-        
+
     logging.info("Starting legacy database setup process...")
 
     for db_name in legacy_dbs:
         logging.info(f"--- Processing: {db_name} ---")
-        
+
         # Create the database
         if not create_database(db_config, db_name):
             continue # Skip to next DB if creation failed
@@ -179,6 +189,7 @@ def main() -> None:
         populate_database(db_config, db_name, sql_file)
 
     logging.info("--- Legacy database setup process complete. ---")
+
 
 if __name__ == "__main__":
     main()

--- a/phases/01_LegacyDB/src/01_create_benchmark_dbs.py
+++ b/phases/01_LegacyDB/src/01_create_benchmark_dbs.py
@@ -50,6 +50,8 @@ BENCHMARK_DB_TO_SQL_MAP = {
 
 
 # --- Logging Setup ---
+
+
 def setup_logging(log_path: Path) -> None:
     """Configures logging to both console and a file."""
     logging.basicConfig(
@@ -63,6 +65,7 @@ def setup_logging(log_path: Path) -> None:
 
 
 # --- Argument Parsing ---
+
 def parse_arguments() -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -78,6 +81,8 @@ def parse_arguments() -> argparse.Namespace:
 
 
 # --- Database Operations ---
+
+
 def create_database(db_config: Dict, db_name: str) -> bool:
     """Creates a new PostgreSQL database if it doesn't already exist."""
     logging.info(f"Attempting to create database: '{db_name}'...")
@@ -113,7 +118,7 @@ def extract_transform_data(engine: Engine, query_path: Path) -> pd.DataFrame | N
     if not query_path.is_file():
         logging.critical(f"SQL query file not found at: {query_path}")
         return None
-    
+
     logging.info(f"Reading query from '{query_path.name}'...")
     with open(query_path, 'r', encoding='utf-8') as f:
         query = f.read()
@@ -156,7 +161,7 @@ def main() -> None:
     """Main function to orchestrate the benchmark database creation."""
     args = parse_arguments()
     config_path = Path(args.config)
-    
+
     log_file_path = Path(__file__).parent / LOG_FILE_NAME
     setup_logging(log_file_path)
 
@@ -178,7 +183,7 @@ def main() -> None:
     except (configparser.NoSectionError, configparser.NoOptionError) as e:
         logging.critical(f"Config file is missing a required section or option: {e}")
         sys.exit(1)
-        
+
     logging.info("Starting benchmark database creation process...")
 
     # 1. Create the empty benchmark databases first
@@ -194,7 +199,7 @@ def main() -> None:
     for db_name, sql_filename in BENCHMARK_DB_TO_SQL_MAP.items():
         logging.info(f"--- Processing benchmark database: {db_name} ---")
         query_path = sql_dir / sql_filename
-        
+
         # Extract and Transform using the specified SQL query
         df = extract_transform_data(source_engine, query_path)
         if df is None:
@@ -205,7 +210,7 @@ def main() -> None:
         target_engine = get_sqlalchemy_engine(db_config_root, db_name)
         if not write_to_database(df, target_engine):
             logging.error(f"Halting: failed to load data into {db_name}.")
-            
+
     logging.info("--- Benchmark database creation process complete. ---")
 
 

--- a/phases/01_LegacyDB/src/03_generate_erds.py
+++ b/phases/01_LegacyDB/src/03_generate_erds.py
@@ -66,7 +66,10 @@ TMP_DF9_SUBSYSTEMS = {
 
 
 # --- Setup Functions ---
+
+
 def setup_logging(log_dir: Path) -> None:
+
     """Configures logging to both console and a file."""
     log_dir.mkdir(exist_ok=True)
     log_path = log_dir / LOG_FILE_NAME
@@ -79,6 +82,7 @@ def setup_logging(log_dir: Path) -> None:
         ]
     )
 
+
 def parse_arguments() -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -89,6 +93,7 @@ def parse_arguments() -> argparse.Namespace:
         help="Path to the configuration file (default: config.ini)"
     )
     return parser.parse_args()
+
 
 def get_sqlalchemy_engine(db_config: Dict[str, Any], db_name: str) -> Engine | None:
     """Creates a SQLAlchemy engine, returning None on failure."""
@@ -102,12 +107,14 @@ def get_sqlalchemy_engine(db_config: Dict[str, Any], db_name: str) -> Engine | N
         logging.error(f"Failed to create SQLAlchemy engine for '{db_name}': {e}")
         return None
 
+
 def get_schema_for_db(db_name: str, legacy_dbs: List[str]) -> str:
     """Determines the correct schema name for a given database name."""
     return db_name if db_name in legacy_dbs else 'public'
 
 
 # --- Core Graphing Logic ---
+
 def generate_and_save_erd(
     metadata: MetaData,
     output_path: Path,
@@ -145,6 +152,7 @@ def generate_and_save_erd(
 
 
 # --- Main Orchestrator ---
+
 def main() -> None:
     """Main function to orchestrate ERD generation for all databases."""
     args = parse_arguments()
@@ -167,11 +175,11 @@ def main() -> None:
         legacy_dbs = [db.strip() for db in config.get("databases", "legacy_dbs").split(',')]
         benchmark_dbs = [db.strip() for db in config.get("databases", "benchmark_dbs").split(',')]
         all_dbs_to_profile = legacy_dbs + benchmark_dbs
-        
+
         project_root = Path(__file__).parent.parent
         output_dir = project_root / OUTPUT_ERDS_DIR
         output_dir.mkdir(parents=True, exist_ok=True)
-        
+
     except (configparser.NoSectionError, configparser.NoOptionError) as e:
         logging.critical(f"Config file is missing a required section or option: {e}")
         sys.exit(1)
@@ -209,13 +217,13 @@ def main() -> None:
         if db_name == 'tmp_df9':
             logging.info(f"Generating focused ERDs for '{db_name}'...")
             for subsystem_name, table_list in TMP_DF9_SUBSYSTEMS.items():
-                
+
                 # Filter the reflected tables to only those in our subsystem list
                 tables_to_include = [
                     table for name, table in metadata.tables.items()
                     if name.split('.')[-1] in table_list
                 ]
-                
+
                 if not tables_to_include:
                     logging.warning(f"No tables found for subsystem '{subsystem_name}'. Skipping.")
                     continue

--- a/phases/01_LegacyDB/src/04_run_comparison.py
+++ b/phases/01_LegacyDB/src/04_run_comparison.py
@@ -35,6 +35,7 @@ OUTPUT_REPORTS_DIR = "outputs/reports"
 
 
 # --- Setup Functions ---
+
 def setup_logging(log_dir: Path) -> None:
     """Configures logging to both console and a file."""
     log_dir.mkdir(exist_ok=True)
@@ -64,6 +65,7 @@ def parse_arguments() -> argparse.Namespace:
 
 
 # --- Core Logic ---
+
 def load_all_metrics(input_dir: Path) -> Dict[str, Dict[str, Any]]:
     """
      Discovers and loads all metric files from the input directory.
@@ -103,7 +105,7 @@ def load_all_metrics(input_dir: Path) -> Dict[str, Dict[str, Any]]:
                     metric_name = suffix
                     db_name = stem.rsplit(f"_{suffix}", 1)[0]
                     break
-            
+
             if not db_name:
                 logging.warning(f"Could not determine database name for '{file_path.name}'. Skipping.")
                 continue
@@ -115,7 +117,7 @@ def load_all_metrics(input_dir: Path) -> Dict[str, Dict[str, Any]]:
                     all_data[db_name][metric_name] = json.load(f)
         except Exception as e:
             logging.exception(f"Failed to load or parse file '{file_path.name}': {e}")
-    
+
     return dict(all_data)
 
 
@@ -129,11 +131,11 @@ def calculate_summary_metrics(db_name: str, db_data: Dict[str, Any]) -> Dict[str
 
     Returns:
         A flat dictionary of aggregated metrics.
-    
+
     This preserves the original summary logic.
     """
     summary = {"Database": db_name}
-    
+
     # Helper to safely get data and log if missing
     def get_metric_data(key, default=None):
         data = db_data.get(key)
@@ -222,7 +224,7 @@ def generate_markdown_report(summary_df: pd.DataFrame, perf_summary_df: pd.DataF
         report_parts.append("This table shows how many times slower each database is compared to the fastest benchmark database for each query category. A value of 1.0 means it is as fast as the benchmark.")
         pivot_efficiency = perf_summary_df.pivot_table(index='database', columns='category', values='schema_efficiency_factor', aggfunc='mean').round(2)
         report_parts.append(pivot_efficiency.to_markdown())
-        
+
         report_parts.append("\n### Detailed Latency Breakdown (ms)")
         pivot_latency = perf_summary_df.pivot_table(index=['category', 'query_id'], columns='database', values='latency_ms').round(2)
         report_parts.append(pivot_latency.to_markdown())
@@ -241,6 +243,7 @@ def generate_markdown_report(summary_df: pd.DataFrame, perf_summary_df: pd.DataF
 
 
 # --- Main Orchestrator ---
+
 def main() -> None:
     """Main function to orchestrate the comparison and aggregation process."""
     args = parse_arguments()

--- a/phases/01_LegacyDB/src/profiling_modules/base.py
+++ b/phases/01_LegacyDB/src/profiling_modules/base.py
@@ -33,6 +33,7 @@ def get_table_names(engine: Engine, schema_name: str) -> List[str]:
         logging.error(f"Failed to get table names for schema '{schema_name}': {e}")
         return []
 
+
 def get_view_names(engine: Engine, schema_name: str) -> List[str]:
     """
     Retrieves a list of all view names in a given schema.

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_basic.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_basic.py
@@ -30,7 +30,7 @@ def get_basic_db_metrics(engine: Engine) -> Dict[str, Any]:
             db_size_query = text("SELECT pg_catalog.pg_database_size(current_database()) / (1024 * 1024);")
             db_size_result = connection.execute(db_size_query)
             metrics["database_size_mb"] = round(db_size_result.scalar_one(), 2)
-            
+
             logging.info(f"Successfully retrieved basic metrics for DB '{metrics['database_name']}'.")
 
     except Exception as e:
@@ -57,7 +57,7 @@ def get_schema_object_counts(engine: Engine, schema_name: str) -> Dict[str, Any]
         "function_count": 0,
         "sequence_count": 0,
     }
-    
+
     queries = {
         "function_count": text("SELECT COUNT(*) FROM information_schema.routines WHERE routine_schema = :schema;"),
         "sequence_count": text("SELECT COUNT(*) FROM information_schema.sequences WHERE sequence_schema = :schema;")

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_interop.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_interop.py
@@ -29,7 +29,7 @@ def calculate_interoperability_metrics(engine: Engine, schema_name: str) -> Dict
         "lif": None,
         "nf": None
     }
-    
+
     # --- JDI Calculation ---
     fk_query = text("""
         SELECT COUNT(*)

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_profile.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_profile.py
@@ -71,7 +71,7 @@ def get_all_column_profiles(engine: Engine, schema_name: str) -> List[Dict[str, 
             else:
                 record['null_count_estimate'] = 0
             all_profiles.append(record)
-            
+
         logging.info(f"Successfully generated column profiles for {len(all_profiles)} columns in schema '{schema_name}' using pg_stats.")
 
     except Exception as e:

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_schema.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_schema.py
@@ -79,7 +79,7 @@ def get_table_level_metrics(engine: Engine, schema_name: str) -> List[Dict[str, 
     try:
         with engine.connect() as connection:
             df = pd.read_sql_query(query, connection, params={"schema": schema_name})
-        
+
         # Calculate bloat in Python for clarity
         df['bloat_bytes'] = df['actual_size_b'] - df['expected_size_b']
         df['bloat_percent'] = round(
@@ -89,7 +89,7 @@ def get_table_level_metrics(engine: Engine, schema_name: str) -> List[Dict[str, 
 
         # Drop helper columns before returning
         df = df.drop(columns=['expected_size_b', 'actual_size_b'])
-        
+
         table_metrics = df.to_dict('records')
         logging.info(f"Successfully calculated table-level metrics for {len(table_metrics)} tables in schema '{schema_name}'.")
 


### PR DESCRIPTION
## Summary
- clean trailing whitespace and extra blank lines in legacy DB scripts
- ensure two blank lines before top-level functions for better readability

## Testing
- `flake8 phases/01_LegacyDB/src | head -n 20`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa41a7ee0832d901e33544ad41002