### PR TITLE
Format legacy scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.5
+    hooks:
+      - id: ruff
+      - id: ruff-format

--- a/phases/01_LegacyDB/src/00_setup_databases.py
+++ b/phases/01_LegacyDB/src/00_setup_databases.py
@@ -18,6 +18,7 @@ Usage:
     $ python 00_setup_databases.py --config config.ini
 
 """
+
 import argparse
 import configparser
 import logging
@@ -33,6 +34,8 @@ LOG_FILE_NAME = "00_setup_databases.log"
 
 
 # --- Logging Setup ---
+
+
 def setup_logging(log_path: Path) -> None:
     """Configures logging to both console and a file."""
     logging.basicConfig(
@@ -43,6 +46,8 @@ def setup_logging(log_path: Path) -> None:
 
 
 # --- Argument Parsing ---
+
+
 def parse_arguments() -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -58,6 +63,8 @@ def parse_arguments() -> argparse.Namespace:
 
 
 # --- Database Operations ---
+
+
 def create_database(db_config: dict, db_name: str) -> bool:
     """
     Creates a new database in PostgreSQL if it doesn't already exist.
@@ -134,6 +141,8 @@ def populate_database(db_config: dict, db_name: str, sql_file_path: Path) -> boo
 
 
 # --- Main Orchestrator ---
+
+
 def main() -> None:
     """Main function to orchestrate database setup."""
     args = parse_arguments()

--- a/phases/01_LegacyDB/src/01_create_benchmark_dbs.py
+++ b/phases/01_LegacyDB/src/01_create_benchmark_dbs.py
@@ -23,6 +23,7 @@ Usage:
     $ python 01_create_benchmark_dbs.py --config config.ini
 
 """
+
 import argparse
 import configparser
 import logging
@@ -50,6 +51,8 @@ BENCHMARK_DB_TO_SQL_MAP = {
 
 
 # --- Logging Setup ---
+
+
 def setup_logging(log_path: Path) -> None:
     """Configures logging to both console and a file."""
     logging.basicConfig(
@@ -63,6 +66,8 @@ def setup_logging(log_path: Path) -> None:
 
 
 # --- Argument Parsing ---
+
+
 def parse_arguments() -> argparse.Namespace:
     """Parses command-line arguments."""
     parser = argparse.ArgumentParser(
@@ -78,6 +83,8 @@ def parse_arguments() -> argparse.Namespace:
 
 
 # --- Database Operations ---
+
+
 def create_database(db_config: Dict, db_name: str) -> bool:
     """Creates a new PostgreSQL database if it doesn't already exist."""
     logging.info("Attempting to create database: '%s'...", db_name)
@@ -167,6 +174,8 @@ def write_to_database(df: pd.DataFrame, engine: Engine) -> bool:
 
 
 # --- Main Orchestrator ---
+
+
 def main() -> None:
     """Main function to orchestrate the benchmark database creation."""
     args = parse_arguments()

--- a/phases/01_LegacyDB/src/02_run_profiling_pipeline.py
+++ b/phases/01_LegacyDB/src/02_run_profiling_pipeline.py
@@ -21,6 +21,7 @@ Usage:
     $ python 02_run_profiling_pipeline.py --config config.ini
 
 """
+
 import argparse
 import configparser
 import json
@@ -34,7 +35,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
 # Import all our profiling functions
-from profiling_modules import base
 from profiling_modules import metrics_basic
 from profiling_modules import metrics_schema
 from profiling_modules import metrics_profile
@@ -47,6 +47,8 @@ OUTPUT_METRICS_DIR = "outputs/metrics"
 
 
 # --- Setup Functions ---
+
+
 def setup_logging(log_dir: Path) -> None:
     """Configures logging to both console and a file."""
     log_dir.mkdir(exist_ok=True)
@@ -138,6 +140,8 @@ def save_results(
 
 
 # --- Main Orchestrator ---
+
+
 def main() -> None:
     """Main function to orchestrate the entire profiling pipeline."""
     args = parse_arguments()

--- a/phases/01_LegacyDB/src/03_generate_erds.py
+++ b/phases/01_LegacyDB/src/03_generate_erds.py
@@ -26,6 +26,7 @@ Usage:
     $ python 03_generate_erds.py --config config.ini
 
 """
+
 import argparse
 import configparser
 import logging
@@ -90,6 +91,8 @@ TMP_DF9_SUBSYSTEMS = {
 
 
 # --- Setup Functions ---
+
+
 def setup_logging(log_dir: Path) -> None:
     """Configures logging to both console and a file."""
     log_dir.mkdir(exist_ok=True)
@@ -141,6 +144,8 @@ def get_schema_for_db(db_name: str, legacy_dbs: List[str]) -> str:
 
 
 # --- Core Graphing Logic ---
+
+
 def generate_and_save_erd(
     metadata: MetaData,
     output_path: Path,
@@ -187,6 +192,8 @@ def generate_and_save_erd(
 
 
 # --- Main Orchestrator ---
+
+
 def main() -> None:
     """Main function to orchestrate ERD generation for all databases."""
     args = parse_arguments()
@@ -270,7 +277,6 @@ def main() -> None:
         if db_name == "tmp_df9":
             logging.info("Generating focused ERDs for '%s'...", db_name)
             for subsystem_name, table_list in TMP_DF9_SUBSYSTEMS.items():
-
                 # Filter the reflected tables to only those in our subsystem list
                 tables_to_include = [
                     table

--- a/phases/01_LegacyDB/src/04_run_comparison.py
+++ b/phases/01_LegacyDB/src/04_run_comparison.py
@@ -16,6 +16,7 @@ not connect to any databases. Instead, it performs the following steps:
     d) `report_performance_pivot_efficiency.csv`: A pivot table for at-a-glance
        comparison of schema efficiency.
 """
+
 import argparse
 import configparser
 import json
@@ -35,6 +36,8 @@ OUTPUT_REPORTS_DIR = "outputs/reports"
 
 
 # --- Setup Functions ---
+
+
 def setup_logging(log_dir: Path) -> None:
     """Configures logging to both console and a file."""
     log_dir.mkdir(exist_ok=True)
@@ -64,6 +67,8 @@ def parse_arguments() -> argparse.Namespace:
 
 
 # --- Core Logic ---
+
+
 def load_all_metrics(input_dir: Path) -> Dict[str, Dict[str, Any]]:
     """
      Discovers and loads all metric files from the input directory.
@@ -111,7 +116,8 @@ def load_all_metrics(input_dir: Path) -> Dict[str, Dict[str, Any]]:
 
             if not db_name:
                 logging.warning(
-                    "Could not determine database name for '%s'. Skipping.", file_path.name
+                    "Could not determine database name for '%s'. Skipping.",
+                    file_path.name,
                 )
                 continue
 
@@ -243,7 +249,7 @@ def generate_markdown_report(
         output_path,
     )
     report_parts = [
-        f"# Database Comparison Report",
+        "# Database Comparison Report",
         f"_Generated on: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}_",
     ]
 
@@ -299,6 +305,8 @@ def generate_markdown_report(
 
 
 # --- Main Orchestrator ---
+
+
 def main() -> None:
     """Main function to orchestrate the comparison and aggregation process."""
     args = parse_arguments()

--- a/phases/01_LegacyDB/src/profiling_modules/base.py
+++ b/phases/01_LegacyDB/src/profiling_modules/base.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 """Base utility functions for database object discovery."""
+
 import logging
-from typing import Any, Dict, List
+from typing import List
 
 from sqlalchemy import text
 from sqlalchemy.engine import Engine

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_basic.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_basic.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functions for calculating basic database and schema-level metrics."""
+
 import logging
 from typing import Any, Dict
 

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_interop.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_interop.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Functions for calculating custom interoperability metrics."""
+
 import logging
 from typing import Any, Dict
-
-import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_performance.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_performance.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Enhanced functions for running database-specific performance benchmarks."""
+
 import json
 import logging
 import time
@@ -206,7 +207,7 @@ def run_legacy_benchmarks(
 
     with engine.connect() as connection:
         for i, query in enumerate(queries):
-            query_name = f"Query {i+1}"
+            query_name = f"Query {i + 1}"
             result_entry = {
                 "query_name": query_name,
                 "sql_query": query,

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_profile.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_profile.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functions for profiling the data content within columns."""
+
 import logging
 from typing import Any, Dict, List
 

--- a/phases/01_LegacyDB/src/profiling_modules/metrics_schema.py
+++ b/phases/01_LegacyDB/src/profiling_modules/metrics_schema.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Functions for calculating structural schema, table, and column metrics."""
+
 import logging
 from typing import Any, Dict, List
 


### PR DESCRIPTION
## Summary
- run ruff formatter on legacy DB scripts
- fix unused imports and a malformed f-string
- add missing blank lines before top-level functions
- add a minimal pre-commit config using ruff

## Testing
- `pre-commit run --files phases/01_LegacyDB/src/*.py phases/01_LegacyDB/src/profiling_modules/*.py`
- `flake8 phases/01_LegacyDB/src`

------
https://chatgpt.com/codex/tasks/task_e_684aaea6aea4832d838b36f97f45dea8

## Summary by Sourcery

Apply ruff formatting to legacy database scripts, correct code style issues, and introduce a basic pre-commit configuration.

Enhancements:
- Run ruff formatter across legacy DB scripts
- Insert missing blank lines before top-level function definitions
- Fix multiline logging call argument formatting
- Replace a redundant f-string with a plain string literal
- Remove unused imports

CI:
- Add .pre-commit-config.yaml with ruff and ruff-format hooks