### PR TITLE
Update Ruff line-length config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,8 @@
 # Ruff configuration: https://docs.astral.sh/ruff/configuration/
 # Set the Python version to target. This is based on your `base_project_env.yml`.
 target-version = "py311"
+# Match Black's default line length
+line-length = 88
 
 # Define the set of rules to use.
 # E/W = pycodestyle errors/warnings
@@ -41,7 +43,6 @@ exclude = [
 [tool.ruff.format]
 # Ruff formatter configuration (replaces Black)
 # Use a line length of 88, which is the standard for Black.
-line-length = 88
 # Enables preview mode for new formatting features.
 preview = true
 


### PR DESCRIPTION
## Summary
- configure Ruff's global line-length in `pyproject.toml`
- remove duplicate line-length from `tool.ruff.format`

## Testing
- `pre-commit run --files pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_684b03e3b410832dadf38ff223c4c610

## Summary by Sourcery

Centralize Ruff’s line-length setting in the global pyproject.toml configuration and remove the redundant per-format setting

Enhancements:
- Configure Ruff’s global line-length to 88 in pyproject.toml
- Remove duplicate line-length entry from the tool.ruff.format section