### PR TITLE
Update Ruff settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@
 # Ruff configuration: https://docs.astral.sh/ruff/configuration/
 # Set the Python version to target. This is based on your `base_project_env.yml`.
 target-version = "py311"
-# Match Black's default line length
 line-length = 88
+# Match Black's default line length
 
 # Define the set of rules to use.
 # E/W = pycodestyle errors/warnings


### PR DESCRIPTION
## Summary
- ensure `line-length = 88` follows `target-version` in `pyproject.toml`
- verify Ruff configuration via pre-commit

## Testing
- `pre-commit run --files pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_684b3d7e8868832d8da5b15dc3de7f75