### PR TITLE
Fix ERD generation config parsing

### DIFF
--- a/phases/01_LegacyDB/src/00_setup_databases.py
+++ b/phases/01_LegacyDB/src/00_setup_databases.py
@@ -23,7 +23,18 @@ import os
 import re
 import subprocess
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass as _dataclass
+import types
+
+
+def dataclass(*args, **kwargs):
+    """Safely apply ``dataclasses.dataclass`` even if module isn't registered."""
+    def wrapper(cls):
+        if cls.__module__ not in sys.modules:
+            sys.modules[cls.__module__] = types.ModuleType(cls.__module__)
+        return _dataclass(*args, **kwargs)(cls)
+
+    return wrapper
 from pathlib import Path
 from typing import List
 

--- a/phases/01_LegacyDB/src/01_create_benchmark_dbs.py
+++ b/phases/01_LegacyDB/src/01_create_benchmark_dbs.py
@@ -18,7 +18,18 @@ import configparser
 import logging
 import re
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass as _dataclass
+import types
+
+
+def dataclass(*args, **kwargs):
+    """Safely apply ``dataclasses.dataclass`` even if module isn't registered."""
+    def wrapper(cls):
+        if cls.__module__ not in sys.modules:
+            sys.modules[cls.__module__] = types.ModuleType(cls.__module__)
+        return _dataclass(*args, **kwargs)(cls)
+
+    return wrapper
 from pathlib import Path
 from typing import List
 

--- a/phases/01_LegacyDB/src/03_generate_erds.py
+++ b/phases/01_LegacyDB/src/03_generate_erds.py
@@ -224,10 +224,14 @@ def main() -> None:
     try:
         db_config_root = dict(config["postgresql"])
         legacy_dbs = [
-            db.strip() for db in config.get("databases", "legacy_dbs").split(",")
+            db.strip()
+            for db in config.get("databases", "legacy_dbs").split(",")
+            if db.strip()
         ]
         benchmark_dbs = [
-            db.strip() for db in config.get("databases", "benchmark_dbs").split(",")
+            db.strip()
+            for db in config.get("databases", "benchmark_dbs").split(",")
+            if db.strip()
         ]
         all_dbs_to_profile = legacy_dbs + benchmark_dbs
 


### PR DESCRIPTION
## Summary
- avoid empty database names when reading config lists
- ensure dataclasses do not fail when modules are loaded dynamically

## Testing
- `pytest tests/p1_w2/test_generate_erds.py -q` *(fails: file not found)*
- `pytest -q` *(fails to run all tests due to missing module and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6865681c81f4832d932dbad7f4d2b847

## Summary by Sourcery

Fix ERD generation configuration parsing and dynamic dataclass loading.

Bug Fixes:
- Filter out empty database names when reading legacy and benchmark DB lists from config
- Prevent dataclass loading failures when modules are imported dynamically