### PR TITLE
Fix ERD generator case handling and API usage

### DIFF
--- a/phases/01_LegacyDB/src/03_generate_erds.py
+++ b/phases/01_LegacyDB/src/03_generate_erds.py
@@ -178,7 +178,7 @@ def generate_and_save_erd(
     try:
         # Graphviz attributes for improved readability
         graph = create_schema_graph(
-            engine=engine,
+            engine,
             metadata=metadata,
             tables=tables_to_include,
             show_datatypes=False,
@@ -289,7 +289,9 @@ def main() -> None:
         )
 
         # 2. For tmp_df9, generate additional focused ERDs
-        if db_name == "TMP_DF9":
+        #    Normalize the database name to handle case differences when
+        #    reading from the config file.
+        if db_name.upper() == "TMP_DF9":
             logging.info("Generating focused ERDs for '%s'...", db_name)
             for subsystem_name, table_list in TMP_DF9_SUBSYSTEMS.items():
                 # Create a lowercase table list for case-insensitive matching


### PR DESCRIPTION
## Summary
- support case insensitive TMP_DF9 check so tests pass
- call `create_schema_graph` with engine as a positional argument

## Testing
- `pytest tests/p1_w2/test_generate_erds.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68658ba3b7c8832da00461c071b42ce6