### PR TITLE
Fix ERD generation output path handling

### DIFF
--- a/phases/01_LegacyDB/src/03_generate_erds.py
+++ b/phases/01_LegacyDB/src/03_generate_erds.py
@@ -175,6 +175,9 @@ def generate_and_save_erd(
         graph_title,
         output_path.name,
     )
+    # Ensure the output directory exists in case this function is used
+    # independently of the main orchestrator which normally creates it.
+    output_path.parent.mkdir(parents=True, exist_ok=True)
     try:
         # Graphviz attributes for improved readability
         graph = create_schema_graph(


### PR DESCRIPTION
## Summary
- ensure ERD output parent directory exists before writing

## Testing
- `pytest tests/p1_w2/test_generate_erds.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68658e052914832d9045ba9c4bbfcca0

## Summary by Sourcery

Bug Fixes:
- Create the ERD output parent directory if it doesn’t exist before saving